### PR TITLE
Validate and correct desktop entry file

### DIFF
--- a/pick-colour-picker.desktop
+++ b/pick-colour-picker.desktop
@@ -2,14 +2,14 @@
 Type=Application
 Name=pick
 Comment=Pick is a colour picker
-Comment[en_us]=Pick is a color picker
+Comment[en_US]=Pick is a color picker
 GenericName=Colour Picker
-GenericName[en_us]=Color Picker
+GenericName[en_US]=Color Picker
 Icon=pick-colour-picker
 Exec=pick-colour-picker
 Terminal=false
-Actions=AboutDialog;PickFirst
-Keywords=color;colour;picker
+Actions=AboutDialog;PickFirst;
+Keywords=color;colour;picker;
 
 [Desktop Action AboutDialog]
 Name=About Pick
@@ -17,5 +17,5 @@ Exec=pick-colour-picker --about
 
 [Desktop Action PickFirst]
 Name=Pick a colour
-Name[en_us]=Pick a color
+Name[en_US]=Pick a color
 Exec=pick-colour-picker --pick


### PR DESCRIPTION
I tried the `desktop-file-validate` tool from the `desktop-file-utils` package provided by [Freedesktop](https://freedesktop.org) on Pick's desktop entry. Here's the output:

```
/home/hexcube/WorkShop/Projects/ColourPicker/pick-colour-picker.desktop: error: value "AboutDialog;PickFirst" for string list key "Actions" in group "Desktop Entry" does not have a semicolon (';') as trailing character
/home/hexcube/WorkShop/Projects/ColourPicker/pick-colour-picker.desktop: error: value "color;colour;picker" for locale string list key "Keywords" in group "Desktop Entry" does not have a semicolon (';') as trailing character
/home/hexcube/WorkShop/Projects/ColourPicker/pick-colour-picker.desktop: error: action group "Desktop Action AboutDialog" exists, but there is no matching action "AboutDialog"
/home/hexcube/WorkShop/Projects/ColourPicker/pick-colour-picker.desktop: error: action group "Desktop Action PickFirst" exists, but there is no matching action "PickFirst"
```

I corrected those issues by adding the missing semicolons. The second problem was with language codes. According to [Freedesktop Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#localized-keys) country code in language code is uppercase. So, I changed the language code from `en_us` to `en_US` to obey conventions. :grin:
