### PR TITLE
Using gnome-3-28-1804 means we don't need to stage as much

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,30 +70,10 @@ parts:
       snapcraftctl pull
       sed -i 's|Icon=pick-colour-picker|Icon=${SNAP}/usr/share/pixmaps/pick-colour-picker.png|g' pick-colour-picker.desktop
   desktop-gtk3:
-      build-packages:
-        - build-essential
-        - libgtk-3-dev
-      make-parameters:
-        - FLAVOR=gtk3
-      plugin: make
-      source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-      source-subdir: gtk
-      stage-packages:
-        - libxkbcommon0
-        - ttf-ubuntu-font-family
-        - dmz-cursor-theme
-        - light-themes
-        - adwaita-icon-theme
-        - gnome-themes-standard
-        - shared-mime-info
-        - libgtk-3-0
-        - libgdk-pixbuf2.0-0
-        - libglib2.0-bin
-        - libgtk-3-bin
-        - unity-gtk3-module
-        - libappindicator3-1
-        - locales-all
-        - xdg-user-dirs
-        - ibus-gtk3
-        - libibus-1.0-5
-        - fcitx-frontend-gtk3
+    build-packages:
+      - libgtk-3-dev
+    make-parameters:
+      - FLAVOR=gtk3
+    plugin: make
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk


### PR DESCRIPTION
Since we're using the gnome-3-28-1804 content snap we don't need to stage as much.  This saves over 20M.