### PR TITLE
Install appdata file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
 
     data_files=[
         (sys.prefix+'/share/applications',['pick-colour-picker.desktop']),
+        (sys.prefix+'/share/metainfo',['pick-colour-picker.appdata.xml']),
         (sys.prefix+'/share/pixmaps', ['pick-colour-picker.png'])
     ] + icons,
 


### PR DESCRIPTION
It should be placed under `/usr/share/metainfo`. See the [specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location).