### PR TITLE
Bump runtime version to GNOME 44

### DIFF
--- a/org.kryogenix.Pick.yml
+++ b/org.kryogenix.Pick.yml
@@ -1,6 +1,6 @@
 app-id: org.kryogenix.Pick
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '44'
 sdk: org.gnome.Sdk
 command: pick-colour-picker
 


### PR DESCRIPTION
The GNOME flatpak runtime version 42 is deprecated and flatpak warns about this:
```
Info: runtime org.gnome.Platform branch 42 is end-of-life, with reason:
   The GNOME 42 runtime is no longer supported as of March 21, 2023. Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
   org.kryogenix.Pick
```
This PR bumps GNOME runtime version to 44 to fix this.