### PR TITLE
snap: Update to use core22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,5 @@
 name: pick-colour-picker
-version: git
-version-script: |
-  VER=$(grep __VERSION__ pick/__main__.py | head -n 1 | cut -d'=' -f2 | sed 's/ //g' | sed "s/\"//g")
-  REV=$(git rev-parse --short HEAD)
-  echo $VER-$REV
+adopt-info: pick-colour-picker
 summary: A colour picker that remembers where you picked colours from
 description: |
   Choose the colour you want and Pick remembers it, names it, and shows you a screenshot
@@ -13,27 +9,9 @@ description: |
   code or graphics apps.
 icon: pick-colour-picker.png
 
-base: core18
+base: core22
 grade: stable
 confinement: strict
-
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: gnome-platform
-    default-provider: gnome-3-28-1804:gnome-3-28-1804
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/share/themes
-    default-provider: gtk-common-themes:gtk-3-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/share/icons
-    default-provider: gtk-common-themes:icon-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/share/sounds
-    default-provider: gtk-common-themes:sounds-themes
 
 slots:
   pick-colour-picker-dbus:
@@ -43,62 +21,27 @@ slots:
 
 apps:
   pick-colour-picker:
-    environment:
-      XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
-      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libunity
-    command: desktop-launch $SNAP/bin/pick-colour-picker
-    desktop: usr/share/applications/pick-colour-picker.desktop
+    extensions: [ gnome ]
+    command: bin/pick-colour-picker
+    desktop: share/applications/pick-colour-picker.desktop
     plugs:
-      - desktop
-      - gsettings
       - home
-      - unity7
-      - wayland
-      - x11
 
 parts:
-  desktop-gtk3:
-    build-packages:
-      - libgtk-3-dev
-    make-parameters:
-      - FLAVOR=gtk3
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: gtk
-
   pick-colour-picker:
-    after:
-      - desktop-gtk3
     source: .
     plugin: python
-    python-version: python3
-    stage-packages:
-      - gir1.2-dee-1.0
-      - gir1.2-gdkpixbuf-2.0
-      - gir1.2-glib-2.0
-      - gir1.2-gtk-3.0
-      - gir1.2-unity-5.0
-      - python3-cairo
-      - python3-gi
-      - python3-gi-cairo
     override-pull: |
-      snapcraftctl pull
-      sed -i 's|Icon=pick-colour-picker|Icon=${SNAP}/usr/share/pixmaps/pick-colour-picker.png|g' pick-colour-picker.desktop
+      craftctl default
+      sed -i 's|Icon=pick-colour-picker|Icon=${SNAP}/share/pixmaps/pick-colour-picker.png|g' pick-colour-picker.desktop
+      VER=$(grep __VERSION__ pick/__main__.py | head -n 1 | cut -d'=' -f2 | sed 's/ //g' | sed "s/\"//g")
+      REV=$(git rev-parse --short HEAD)
+      craftctl set version=$(echo $VER-$REV)
     # Most of what Pick requires is provided by the GNOME platform snap; so just prime what we need.
     prime:
       - bin
-      - command-*.wrapper
-      - flavor-select
       - lib
-      - usr/bin/python*
-      - usr/lib/girepository-1.0
-      - usr/lib/python3*
-      - usr/lib/*/gio
-      - usr/lib/*/girepository-1.0
-      - usr/lib/*/libdbusmenu*
-      - usr/lib/*/libdee*
-      - usr/lib/*/libunity*
-      - usr/share/applications/pick-colour-picker.desktop
-      - usr/share/icons/hicolor/*/apps/pick-colour-picker.png
-      - usr/share/icons/hicolor/*/apps/pick-colour-picker-symbolic.svg
-      - usr/share/pixmaps/pick-colour-picker.png
+      - share/applications/pick-colour-picker.desktop
+      - share/icons/hicolor/*/apps/pick-colour-picker.png
+      - share/icons/hicolor/*/apps/pick-colour-picker-symbolic.svg
+      - share/pixmaps/pick-colour-picker.png


### PR DESCRIPTION
In theory this should work with the latest gnome extension and core22.  Although setuptools wasn't quite doing the right thing.